### PR TITLE
Add branded 404 fallback page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Page not found • Honors Showroom</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%20100%20100'%3E%3Ctext%20y%3D'.9em'%20font-size%3D'90'%3E%F0%9F%97%A0%3C%2Ftext%3E%3C%2Fsvg%3E">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body {
+      display: grid;
+      place-items: center;
+      min-height: 100vh;
+      margin: 0;
+      text-align: center;
+      background: #fafafa;
+      color: #1f2933;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      padding: 2rem;
+    }
+    main {
+      max-width: 640px;
+      background: #fff;
+      border-radius: 20px;
+      box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+      padding: 3rem 2.5rem;
+      display: grid;
+      gap: 1.25rem;
+    }
+    h1 {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 2.75rem);
+    }
+    p {
+      margin: 0;
+      font-size: 1.1rem;
+      color: #425466;
+    }
+    a {
+      color: #111827;
+      font-weight: 600;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Oops — page not found</h1>
+    <p>The link may be out of date or the page might have moved.</p>
+    <p><a href="/">Return to the catalog</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated 404.html page for missing catalog routes
- include centered layout styling and link back to the showroom

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ce1207689c832ebd4d9d982ffc6a4e