### PR TITLE
Add Honors header and enhance catalog filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,21 +8,35 @@
   <meta name="robots" content="noindex" />
 </head>
 <body>
-  <header class="container">
-    <h1>Honors Showroom</h1>
-    <div class="controls">
-      <input id="search" type="search" placeholder="Search name, vendor, SKU…" />
-      <select id="category"><option value="">All categories</option></select>
-      <select id="sort">
-        <option value="name-asc">Name A–Z</option>
-        <option value="name-desc">Name Z–A</option>
-        <option value="price-asc">Price ↑</option>
-        <option value="price-desc">Price ↓</option>
-      </select>
+  <div class="topbar">
+    <div class="wrap">
+      <span>Email: <a href="mailto:sales@honorsone.com">sales@honorsone.com</a></span>
+      <span>•</span>
+      <a href="tel:+12485825200">248.582.5200</a>
+    </div>
+  </div>
+
+  <header class="site-header">
+    <div class="wrap nav">
+      <a class="brand" href="#">
+        <img src="Assets/Honors%20Thick%20Logo.png" alt="Honors" />
+      </a>
+      <nav class="navlinks" id="nav"></nav>
+    </div>
+    <div class="wrap controls">
+      <input id="q" type="search" placeholder="Search products, tags, vendor…" />
+      <select id="cat"><option value="">All Categories</option></select>
+      <select id="imp"><option value="">All Imprint Methods</option></select>
+      <select id="tag"><option value="">All Tags</option></select>
     </div>
   </header>
 
-  <main id="grid" class="grid container" aria-live="polite"></main>
+  <main class="wrap content">
+    <div class="results-meta">
+      <p id="count">Loading…</p>
+    </div>
+    <section id="grid" class="grid" aria-live="polite"></section>
+  </main>
 
   <template id="card-tpl">
     <article class="card">

--- a/styles.css
+++ b/styles.css
@@ -1,29 +1,291 @@
-:root { --gap: 16px; --radius: 16px; --shadow: 0 6px 18px rgba(0,0,0,.08); }
-* { box-sizing: border-box; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #fafafa; color: #222; }
-.container { max-width: 1200px; margin: 0 auto; padding: 16px; }
-header { position: sticky; top: 0; background: #fafafa; border-bottom: 1px solid #eee; z-index: 10; }
-h1 { margin: 8px 0 12px; font-size: 1.6rem; }
-.controls { display: grid; grid-template-columns: 1fr 200px 200px; gap: var(--gap); }
-.controls input, .controls select { padding: 10px 12px; border-radius: 10px; border: 1px solid #ddd; background: #fff; }
-.grid { display: grid; gap: var(--gap); grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); margin-top: 16px; }
-.card { background: #fff; border-radius: var(--radius); box-shadow: var(--shadow); display: flex; flex-direction: column; overflow: hidden; }
-.card-img { width: 100%; aspect-ratio: 4/3; object-fit: cover; background: #f2f2f2; }
-.card-body { padding: 14px; display: grid; gap: 10px; }
-.card-title { margin: 0; font-size: 1.05rem; }
-.card-sub { margin: 0; color: #666; font-size: .9rem; }
-.card-desc { margin: 0; color: #444; font-size: .9rem; white-space: pre-line; }
-.price { font-weight: 600; font-size: 1rem; }
-.card-meta { display: flex; flex-wrap: wrap; gap: 6px; font-size: .85rem; color: #333; }
-.badge { background: #f3f4f6; border: 1px solid #e5e7eb; padding: 2px 8px; border-radius: 999px; }
-.card-section { border-top: 1px solid #eee; padding-top: 8px; margin-top: 4px; display: grid; gap: 6px; }
-.card-section h3 { margin: 0; font-size: .75rem; letter-spacing: .04em; text-transform: uppercase; color: #555; }
-.card-list { margin: 0; padding: 0; list-style: none; display: grid; gap: 4px; }
-.card-list-item { display: flex; gap: 8px; justify-content: space-between; font-size: .85rem; color: #333; }
-.card-list-item .price { font-weight: 600; }
-.card-list-item.muted { color: #777; font-style: italic; justify-content: flex-start; }
-.card-list-label { flex: 1; }
-.card-actions { display: flex; gap: 8px; margin-top: 6px; }
-.button { appearance: none; border: 1px solid #ddd; background: #fff; border-radius: 999px; padding: 8px 12px; font-size: .9rem; cursor: pointer; }
-.button.primary { background: #111827; color: #fff; border-color: #111827; }
-.empty { grid-column: 1 / -1; text-align: center; color: #666; padding: 48px 0; }
+:root {
+  --wrap: 1200px;
+  --pad: 20px;
+  --gap: 16px;
+  --radius: 16px;
+  --shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+  --brand: #b1976b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: #f5f5f5;
+  color: #222;
+}
+
+a {
+  color: inherit;
+}
+
+.wrap {
+  max-width: var(--wrap);
+  margin: 0 auto;
+  padding: 0 var(--pad);
+}
+
+.topbar {
+  background: #111;
+  color: #fff;
+  font-size: 13px;
+}
+
+.topbar .wrap {
+  padding: 6px var(--pad);
+  display: flex;
+  gap: 18px;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.topbar a {
+  color: #fff;
+  opacity: 0.9;
+  text-decoration: none;
+}
+
+.topbar a:hover {
+  opacity: 1;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  border-bottom: 1px solid #eee;
+  z-index: 10;
+}
+
+.site-header .nav {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 12px var(--pad);
+}
+
+.brand img {
+  height: 40px;
+  width: auto;
+  display: block;
+}
+
+.navlinks {
+  margin-left: auto;
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.navlinks a {
+  font-family: Montserrat, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 14px;
+  color: #111;
+  padding: 6px 8px;
+  border-radius: 8px;
+  text-decoration: none;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.navlinks a:hover {
+  color: var(--brand);
+}
+
+.navlinks a.active {
+  color: #fff;
+  background: var(--brand);
+}
+
+.controls {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 180px 200px 200px;
+  padding: 0 var(--pad) 14px;
+}
+
+.controls input,
+.controls select {
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  background: #fff;
+  font-size: 14px;
+}
+
+.content {
+  padding: 32px var(--pad) 60px;
+}
+
+.results-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+}
+
+.results-meta p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #444;
+}
+
+.grid {
+  display: grid;
+  gap: var(--gap);
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.card-img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: #f2f2f2;
+}
+
+.card-body {
+  padding: 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.card-sub {
+  margin: 0;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.card-desc {
+  margin: 0;
+  color: #444;
+  font-size: 0.9rem;
+  white-space: pre-line;
+}
+
+.price {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #333;
+}
+
+.badge {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.card-section {
+  border-top: 1px solid #eee;
+  padding-top: 8px;
+  margin-top: 4px;
+  display: grid;
+  gap: 6px;
+}
+
+.card-section h3 {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #555;
+}
+
+.card-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.card-list-item {
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #333;
+}
+
+.card-list-item .price {
+  font-weight: 600;
+}
+
+.card-list-item.muted {
+  color: #777;
+  font-style: italic;
+  justify-content: flex-start;
+}
+
+.card-list-label {
+  flex: 1;
+}
+
+.card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.button {
+  appearance: none;
+  border: 1px solid #ddd;
+  background: #fff;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.button.primary {
+  background: #111827;
+  color: #fff;
+  border-color: #111827;
+}
+
+.empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #666;
+  padding: 48px 0;
+}
+
+@media (max-width: 800px) {
+  .controls {
+    grid-template-columns: 1fr;
+    padding-bottom: 18px;
+  }
+
+  .navlinks {
+    display: none;
+  }
+
+  .content {
+    padding-top: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add the Honors contact bar and branded header with new search and filter controls
- extend the theme styles to support the updated header layout, navigation, and responsive spacing
- enrich the catalog script to parse imprint methods, build navigation, and filter products with live counts

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68ce17762170832e9d2f47fcca0c2add